### PR TITLE
Fixes

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -63,6 +63,14 @@
          "i8" "i16" "i32" "i64"
          "u8" "u16" "u32" "u64"))
 
+;; rust has no prefixes for primitives
+(c-lang-defconst c-primitive-type-prefix-kwds
+  rust nil)
+
+;; rust has no bitfields
+(c-lang-defconst c-bitfield-kwds
+  rust nil)
+
 (c-lang-defconst c-type-modifier-kwds
   rust '("abs"
          "state" "gc"


### PR DESCRIPTION
Hi Graydon,

I've had these two patches to rust-mode sitting around for a while so I thought I should see if you want them. One of them just enables highlighting of c-style comments and the other changes the alignment of statements within obj declaration blocks to 2 spaces, instead of directly under the 'obj' keyword.
