### PR TITLE
Minor improvements to syntax highlighting

### DIFF
--- a/rust-mode.el
+++ b/rust-mode.el
@@ -140,7 +140,7 @@
          (left-assoc ",")
          (left-assoc "=" "*=" "/=" "+=" "-=" "<<=" ">>=" ">>>=" "&=" "|=" "^=")
          (lett-assoc "<|" "<+" "<-")
-         (prefix "spawn" "bind" "@")
+         (prefix "spawn" "thread" "bind" "@")
          (left-assoc "with" "as")))
 
 ;; keywords followed by non-type expressions in parens

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -66,7 +66,8 @@
 (c-lang-defconst c-type-modifier-kwds
   rust '("abs"
          "state" "gc"
-         "impure" "unsafe"))
+         "impure" "unsafe"
+         "const"))
 
 ;; declarator-block openings
 (c-lang-defconst c-other-block-decl-kwds

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -118,6 +118,18 @@
 (c-lang-defconst c-label-kwds
   rust nil)
 
+;; don't highlight "struct", "union", "enum" as in C
+(c-lang-defconst c-type-prefix-kwds
+  rust nil)
+
+;; don't highlight "struct", "union", "enum" as in C
+(c-lang-defconst c-type-list-kwds
+  rust nil)
+
+;; don't highlight "struct", "union", "enum" as in C
+(c-lang-defconst c-class-decl-kwds
+  rust nil)
+
 ;; constants
 (c-lang-defconst c-constant-kwds
   rust '("true" "false"))

--- a/rust-mode.el
+++ b/rust-mode.el
@@ -154,9 +154,6 @@
 (c-lang-defconst c-stmt-delim-chars-with-comma
   rust ";{}")
 
-(c-lang-defconst c-block-comment-starter rust nil)
-(c-lang-defconst c-block-comment-ender rust nil)
-
 ;; No cpp in rust, but there are marked syntax blocks "#foo{...}"
 (c-lang-defconst c-cpp-matchers
   rust (cons


### PR DESCRIPTION
Highlight c-style comments, const & thread keywords. Ignore 'struct', 'union', 'enum' c keywords.
